### PR TITLE
chore: add package bugs metadata

### DIFF
--- a/packages/oxlint-react/package.json
+++ b/packages/oxlint-react/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-react"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-react",

--- a/packages/oxlint-stylistic/package.json
+++ b/packages/oxlint-stylistic/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-stylistic"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-stylistic",
 		"eslint-config-xo",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `@standard-config/oxlint-react`
- add npm `bugs.url` metadata for `@standard-config/oxlint-stylistic`

## Validation
- metadata assertion for both package manifests
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json ./packages/oxlint-react`
- `npm pack --dry-run --ignore-scripts --json ./packages/oxlint-stylistic`
- `corepack pnpm install --frozen-lockfile` (passes; reports the repo Node >=24 engine warning because local Node is v22.22.3)
- `corepack pnpm --filter @standard-config/oxlint-react typecheck`
- `corepack pnpm --filter @standard-config/oxlint-stylistic typecheck`
- `corepack pnpm --filter @standard-config/oxlint-react build`
- `corepack pnpm --filter @standard-config/oxlint-stylistic build`
- commit hook also ran `pnpm install --ignore-scripts`, `pnpm --recursive build`, `pnpm test`, `oxlint --deny-warnings --fix --no-error-on-unmatched-pattern --type-check`, and `prettier --ignore-unknown --write`