### PR TITLE
fix: add bugs metadata to @standard-config/oxlint-react and @standard-config/oxlint-stylistic package.json

### DIFF
--- a/packages/oxlint-react/package.json
+++ b/packages/oxlint-react/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-react"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-react",

--- a/packages/oxlint-stylistic/package.json
+++ b/packages/oxlint-stylistic/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-stylistic"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-stylistic",
 		"eslint-config-xo",


### PR DESCRIPTION
Adds missing `bugs` fields to both package.json files so npm consumers can discover the project's issue tracker.

Fixes charles-openclaw/charles-microbounties#1641