### PR TITLE
Add npm bugs metadata

### DIFF
--- a/packages/oxlint-react/package.json
+++ b/packages/oxlint-react/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-react"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-react",

--- a/packages/oxlint-stylistic/package.json
+++ b/packages/oxlint-stylistic/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-stylistic"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-stylistic",
 		"eslint-config-xo",

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-typescript",


### PR DESCRIPTION
## Summary
- Add npm `bugs` metadata to the published oxlint packages
- Point each package to the repository issue tracker

## Verification
- `git diff --check`
- `pnpm format:check`

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1641