### PR TITLE
Add npm bugs metadata

### DIFF
--- a/packages/oxlint-react/package.json
+++ b/packages/oxlint-react/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-react"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-react",

--- a/packages/oxlint-stylistic/package.json
+++ b/packages/oxlint-stylistic/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint-stylistic"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-stylistic",
 		"eslint-config-xo",

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -14,6 +14,9 @@
 		"url": "git+https://github.com/standard-config/oxlint.git",
 		"directory": "packages/oxlint"
 	},
+	"bugs": {
+		"url": "https://github.com/standard-config/oxlint/issues"
+	},
 	"keywords": [
 		"eslint-config-xo",
 		"eslint-config-xo-typescript",


### PR DESCRIPTION
## Summary
- add npm `bugs` metadata for the public @standard-config/oxlint packages
- point all package bug reports to the repository issues page

## Verification
- `python3 -m json.tool packages/oxlint/package.json`
- `python3 -m json.tool packages/oxlint-react/package.json`
- `python3 -m json.tool packages/oxlint-stylistic/package.json`
- `npm pack --json ./packages/oxlint ./packages/oxlint-react ./packages/oxlint-stylistic --dry-run`
- commit hook ran `pnpm --recursive build`, `pnpm test`, `oxlint --deny-warnings --fix --no-error-on-unmatched-pattern --type-check`, and `prettier --ignore-unknown --write`

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1641
